### PR TITLE
[Feature] Support other currencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ BitpayInvoiceGenerator.prototype = {
       if (invoiceOptions.data) { data = invoiceOptions.data }
       var invoice = {
         price: invoiceOptions.amount,
-        currency: 'BTC',
+        currency: invoiceOptions.currency ? invoiceOptions.currency : 'BTC',
         notificationURL: _this.notificationURL,
         fullNotifications: true,
         posData: JSON.stringify(data)


### PR DESCRIPTION
This adds support for currencies other than BTC.

If the currency parameter is not set, it defaults to BTC so existing configurations don't break.
